### PR TITLE
feat: add json file support

### DIFF
--- a/loader/json.go
+++ b/loader/json.go
@@ -1,0 +1,33 @@
+package loader
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// readJsonFile reads a JSON file and unmarshalls it into the provided data structure.
+func readJsonFile[T any](path string) (T, error) {
+	var data T
+	if !isJsonFile(path) {
+		return data, fmt.Errorf("file '%s' is not a JSON file, supported extensions are [JSON]", path)
+	}
+
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return data, err
+	}
+
+	err = json.Unmarshal(contentBytes, &data)
+	if err != nil {
+		return data, err
+	}
+
+	return data, err
+}
+
+// isJsonFile checks if the file is a JSON file.
+func isJsonFile(path string) bool {
+	return strings.HasSuffix(path, ".json")
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
@@ -11,7 +12,7 @@ import (
 
 // LoadWithName reads the API specification from the provided root directory
 func LoadWithName(rootDir string, apiFileName string) (*model.Spec, error) {
-	content, err := readYamlFile[model.Spec](filepath.Join(rootDir, apiFileName))
+	content, err := readFile[model.Spec](filepath.Join(rootDir, apiFileName))
 	if err != nil {
 		return nil, err
 	}
@@ -58,4 +59,14 @@ func initializeIfNil(obj model.GenericObject) model.GenericObject {
 func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// readFile reads a file and unmarshalls it into the provided data structure.
+func readFile[T any](path string) (data T, err error) {
+	if data, err = readYamlFile[T](path); err == nil {
+		return
+	} else if data, err = readJsonFile[T](path); err == nil {
+		return
+	}
+	return data, fmt.Errorf("file '%s' is not a YAML or JSON file, supported extensions are [yml|yaml|json]", path)
 }


### PR DESCRIPTION
feat: Support both YAML and JSON formats for Swagger output

Previously, only YAML format was supported. This commit adds support for JSON output format to align with the default output of protoc-gen-openapi.