### PR TITLE
Add support for loading from inline spec

### DIFF
--- a/data/embed.go
+++ b/data/embed.go
@@ -1,0 +1,6 @@
+package data
+
+import _ "embed"
+
+//go:embed loader/pet-store.yml
+var PetStoreSpec []byte

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -46,6 +46,16 @@ func LoadFromDir(rootDir string, apiFileName string) (*model.Spec, error) {
 	return sanitizer.Sanitize(specContent), nil
 }
 
+// Load reads the API specification from the provided root directory
+func Load(rootDir string) (*model.Spec, error) {
+	return LoadFromDirRoot(rootDir)
+}
+
+// LoadWithName reads the API specification from the provided root directory
+func LoadWithName(rootDir, apiFileName string) (*model.Spec, error) {
+	return LoadFromDir(rootDir, apiFileName)
+}
+
 // LoadFromDirRoot reads the API specification from the provided root directory
 func LoadFromDirRoot(rootDir string) (*model.Spec, error) {
 	return LoadFromDir(rootDir, "api.yaml")

--- a/main/main.go
+++ b/main/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	scalargo "github.com/bdpiprava/scalar-go"
+	"github.com/bdpiprava/scalar-go/data"
 )
 
 // serverTimeout is the timeout for the server
@@ -74,6 +76,17 @@ func exampleForOtherConfigs() (string, error) {
 	)
 }
 
+// exampleForSpecBytes demonstrates self-contained builds using WithSpecBytes
+func exampleForSpecBytes() (string, error) {
+	return scalargo.NewV2(
+		scalargo.WithSpecBytes(data.PetStoreSpec),
+		scalargo.WithMetaDataOpts(
+			scalargo.WithTitle("Pet Store API (Embedded)"),
+			scalargo.WithKeyValue("Description", "Self-contained build with embedded spec"),
+		),
+	)
+}
+
 type ExampleFn func() (string, error)
 
 func handler(fn ExampleFn) http.HandlerFunc {
@@ -101,6 +114,7 @@ func main() {
 
 	http.HandleFunc("/spec-dir", handler(exampleForSpecDir))
 	http.HandleFunc("/spec-url", handler(exampleForSpecURLAndMetadataUsage))
+	http.HandleFunc("/spec-bytes", handler(exampleForSpecBytes))
 	http.HandleFunc("/servers-override", handler(exampleForServersOverride))
 	http.HandleFunc("/other-configs", handler(exampleForOtherConfigs))
 	http.HandleFunc("/", func(w http.ResponseWriter, request *http.Request) {
@@ -159,6 +173,12 @@ func getExamples() []Example {
 			Description: "This example shows how to read the spec from a URL and add other configurations",
 			Code:        readFuncBodyIgnoreError(reflect.ValueOf(exampleForOtherConfigs)),
 			Output:      ignoreError(exampleForOtherConfigs),
+		},
+		{
+			Name:        "Self-Contained Build with WithSpecBytes",
+			Description: "This example demonstrates how to use WithSpecBytes for self-contained builds with embedded specs",
+			Code:        readFuncBodyIgnoreError(reflect.ValueOf(exampleForSpecBytes)),
+			Output:      ignoreError(exampleForSpecBytes),
 		},
 	}
 }

--- a/options.go
+++ b/options.go
@@ -43,6 +43,7 @@ type Options struct {
 	SpecModifier   SpecModifier
 	SpecDirectory  string
 	SpecURL        string
+	SpecBytes      []byte
 }
 
 type Option func(*Options)
@@ -196,6 +197,13 @@ func WithSpecDir(specDir string) func(*Options) {
 func WithSpecURL(specURL string) func(*Options) {
 	return func(o *Options) {
 		o.SpecURL = specURL
+	}
+}
+
+// WithSpecBytes loads the spec from the provided bytes in either YAML or JSON format
+func WithSpecBytes(specBytes []byte) func(*Options) {
+	return func(o *Options) {
+		o.SpecBytes = specBytes
 	}
 }
 

--- a/scalargo.go
+++ b/scalargo.go
@@ -75,10 +75,6 @@ func renderHTML(title, ccsOverride, specScript, cdn string) string {
 
 // GetSpecScript prepares and returns the spec script, prioritizing SpecURL, then SpecDirectory, then SpecBytes
 func (o *Options) GetSpecScript() (string, error) {
-	if o.SpecURL == "" && o.SpecDirectory == "" && o.SpecBytes == nil {
-		return "", fmt.Errorf("one of SpecURL, SpecDirectory or SpecBytes must be configured")
-	}
-
 	configAsBytes, err := json.Marshal(o.Configurations)
 	if err != nil {
 		return "", err
@@ -104,6 +100,8 @@ func (o *Options) GetSpecScript() (string, error) {
 		if err != nil {
 			return "", err
 		}
+	} else {
+		return "", fmt.Errorf("one of SpecURL, SpecDirectory or SpecBytes must be configured")
 	}
 
 	if o.SpecModifier != nil {

--- a/scalargo.go
+++ b/scalargo.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bdpiprava/scalar-go/loader"
+	"github.com/bdpiprava/scalar-go/model"
 )
 
 // defaultTitle when title is not specified this default is used
@@ -72,8 +73,12 @@ func renderHTML(title, ccsOverride, specScript, cdn string) string {
   `, title, ccsOverride, specScript, cdn)
 }
 
-// GetSpecScript prepare and return spec script
+// GetSpecScript prepares and returns the spec script, prioritizing SpecURL, then SpecDirectory, then SpecBytes
 func (o *Options) GetSpecScript() (string, error) {
+	if o.SpecURL == "" && o.SpecDirectory == "" && o.SpecBytes == nil {
+		return "", fmt.Errorf("one of SpecURL, SpecDirectory or SpecBytes must be configured")
+	}
+
 	configAsBytes, err := json.Marshal(o.Configurations)
 	if err != nil {
 		return "", err
@@ -88,13 +93,17 @@ func (o *Options) GetSpecScript() (string, error) {
 		), nil
 	}
 
-	if strings.TrimSpace(o.SpecDirectory) == "" {
-		return "", fmt.Errorf(`SpecURL or SpecDirectory must be configured`)
-	}
-
-	spec, err := loader.LoadWithName(o.SpecDirectory, o.BaseFileName)
-	if err != nil {
-		return "", err
+	var spec *model.Spec
+	if o.SpecDirectory != "" {
+		spec, err = loader.LoadFromDir(o.SpecDirectory, o.BaseFileName)
+		if err != nil {
+			return "", err
+		}
+	} else if o.SpecBytes != nil {
+		spec, err = loader.LoadFromBytes(o.SpecBytes)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	if o.SpecModifier != nil {

--- a/scalargo_test.go
+++ b/scalargo_test.go
@@ -63,6 +63,14 @@ func Test_NewV2(t *testing.T) {
 			},
 		},
 		{
+			name:      "should render html with inline spec when spec bytes is configured",
+			inputOpts: []scalargo.Option{scalargo.WithSpecBytes([]byte(`{"openapi":"3.0.0","info":{"title":"Swagger Petstore"}}`))},
+			asserter: func(t *testing.T, got html) {
+				require.Empty(t, got.specURL)
+				require.True(t, strings.HasPrefix(got.spec, `{"openapi":"3.0.0","info":{"title":"Swagger Petstore","version":""},"paths":{}`))
+			},
+		},
+		{
 			name: "should render html with authentication configuration",
 			inputOpts: []scalargo.Option{
 				scalargo.WithSpecURL(specURL),

--- a/scalargo_test.go
+++ b/scalargo_test.go
@@ -44,7 +44,7 @@ func Test_NewV2(t *testing.T) {
 			name:      "should return error when no option is provided",
 			inputOpts: []scalargo.Option{},
 			asserter:  func(t *testing.T, got html) { require.Equal(t, html{}, got) },
-			wantError: "SpecURL or SpecDirectory must be configured",
+			wantError: "one of SpecURL, SpecDirectory or SpecBytes must be configured",
 		},
 		{
 			name:      "should render html containing script with spec URL when spec URL is configured",


### PR DESCRIPTION
This PR enables support for passing in a spec as a byte array to support self-contained builds without relying on external filesystem or serving the spec at a separate endpoint.